### PR TITLE
Fix scout scraping NV via refactor, improve docs

### DIFF
--- a/scrapers/items/__init__.py
+++ b/scrapers/items/__init__.py
@@ -1,7 +1,9 @@
 from .bills import (
-    BillStub,
     Chamber,
     BillItem,
+    BillStub,
+    BillStubItem,
+    bill_stub_schema,
     OrganizationItem,
     StateItem,
     VoteEventItem

--- a/scrapers/items/bills.py
+++ b/scrapers/items/bills.py
@@ -1,8 +1,10 @@
 import inspect
+import uuid
 from typing import Any, Union
 from dataclasses import dataclass
 from enum import Enum
 from core.scrape import Bill, State, Organization, VoteEvent
+from core.scrape.base import BaseModel
 
 
 class Chamber(str, Enum):
@@ -12,12 +14,48 @@ class Chamber(str, Enum):
     EXECUTIVE = "executive"
 
 
-@dataclass
-class BillStub:
-    source_url: str
-    identifier: str
-    session: str
-    chamber: Chamber
+bill_stub_schema = {
+    "type": "object",
+    "properties": {
+        "source_url": {"type": "string", "minLength": 1},
+        "identifier": {"type": "string", "minLength": 1},
+        "legislative_session": {"type": "string", "minLength": 1},
+        "chamber": {"type": "string", "enum": Chamber},
+        "extras": {"type": "object"},
+    },
+}
+
+
+class BillStub(BaseModel):
+    _type = "bill_stub"
+    _schema = bill_stub_schema
+
+    def __init__(
+            self,
+            source_url,
+            identifier,
+            legislative_session,
+            chamber,
+    ):
+        super(BillStub, self).__init__()
+
+        self.source_url = source_url
+        self.identifier = identifier
+        self.legislative_session = legislative_session
+        self.chamber = chamber
+
+    def __str__(self):
+        return self.identifier + " in " + self.legislative_session
+
+# @dataclass
+# class BillStub:
+#     source_url: str
+#     identifier: str
+#     session: str
+#     chamber: Chamber
+#
+#     def __init__(self):
+#         self._id = str(uuid.uuid1())
 
 
 class BaseItem:
@@ -35,6 +73,15 @@ class BaseItem:
 @dataclass
 class BillItem(BaseItem):
     def __init__(self, item: Union[Bill, None] = None):
+        super().__init__(item)
+
+    def __repr__(self) -> str:
+        return f'{self.__class__.__name__}({self._id})'
+
+
+@dataclass
+class BillStubItem(BaseItem):
+    def __init__(self, item: Union[BillStub, None] = None):
         super().__init__(item)
 
     def __repr__(self) -> str:

--- a/scrapers/pipelines/drop_stubs.py
+++ b/scrapers/pipelines/drop_stubs.py
@@ -1,12 +1,12 @@
 from itemadapter import ItemAdapter
 from scrapy.exceptions import DropItem
-from ..items import BillStub
+from ..items import BillStubItem
 
 
 class DropStubsPipeline:
     def process_item(self, item, spider):
         adapter = ItemAdapter(item)
-        if adapter.get("is_stub") or type(item) is BillStub or issubclass(type(item), BillStub):
+        if adapter.get("is_stub") or type(item) is BillStubItem or issubclass(type(item), BillStubItem):
             raise DropItem("Dropped stub")
 
         return item

--- a/scrapers/pipelines/save_local.py
+++ b/scrapers/pipelines/save_local.py
@@ -37,7 +37,9 @@ class SaveLocalPipeline:
     def save_object(self, obj, spider):
         clean_whitespace(obj)
 
-        obj.pre_save(spider.jurisdiction.jurisdiction_id)
+        pre_save_method = getattr(obj, "pre_save", None)
+        if callable(pre_save_method):
+            obj.pre_save(spider.jurisdiction.jurisdiction_id)
 
         filename = f"{obj._type}_{obj._id}.json".replace("/", "-")
         file_path = os.path.join(self.datadir, filename)

--- a/scrapers/spiders/__init__.py
+++ b/scrapers/spiders/__init__.py
@@ -1,12 +1,21 @@
-from scrapy import Spider
+from scrapy import Request, Spider
 from scrapers.items import StateItem, OrganizationItem
 
 
 class BaseSpider(Spider):
-    def __init__(self,  **kwargs):
+    def __init__(self, jurisdiction, **kwargs):
+        self.jurisdiction = jurisdiction
         super().__init__(**kwargs)
 
-    def parse(self, response):
+    def start_requests(self):
+        # "fake" request in order to get a callback called: callback doesn't actually use the response
+        # this is a bit of a hack to get entities yielded that Open States convention expects
+        yield Request(url=self.jurisdiction.url, callback=self.yield_jurisdiction_organizations)
+
+        for request in self.do_scrape():
+            yield request
+
+    def yield_jurisdiction_organizations(self, jurisdiction_url_response):
         # Jurisdiction scraper
         # yield a single Jurisdiction object
         if self.jurisdiction:
@@ -15,8 +24,5 @@ class BaseSpider(Spider):
             for org in self.jurisdiction.get_organizations():
                 yield OrganizationItem(org)
 
-        for request in self.do_scrape(response):
-            yield request
-
-    def do_scrape(self, response):
+    def do_scrape(self):
         pass

--- a/scrapers/spiders/us/mo/bills.py
+++ b/scrapers/spiders/us/mo/bills.py
@@ -99,7 +99,6 @@ class BillsSpider(BaseSpider):
     name = "mo-bills"
     jurisdiction = Missouri
     subject_mapping = defaultdict(set)
-    start_urls = ['https://documents.house.mo.gov']
 
     def __init__(self, session=None, chamber=None, **kwargs):
         self.session = session
@@ -107,7 +106,7 @@ class BillsSpider(BaseSpider):
         self.jurisdiction = Missouri()
         super().__init__(**kwargs)
 
-    def do_scrape(self, response):
+    def do_scrape(self):
         # parse subjects
         self.parse_subjects(self.session)
 


### PR DESCRIPTION
The goal here is to get scout scraping working again, which required some refactor to catch up to Bray's work re: output/items. 

Notes:
- Follows the convention of creating an Item that wraps around a domain class (so BillStub and BillStubItem are similar to os-core Bill and this repo's BillItem)
- BillStub would eventually get moved into openstates-core, or another more permanent location. But the `/core` directory is a temporary hack, so I didn't want to really edit in there